### PR TITLE
Add Settings to toggle On/Off Glowing Animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,10 +436,17 @@
                     <button id="howToPlayButton"><i class="icon-info"></i> How to Play?</button>
                     <button id="numberFormatButton" class="full-width-button">Number Format: Mixed</button>
                 </div>
-                <div class="settings-switch">
+                <div class="settings-switch" style="margin-bottom: 10px;">
                     <label for="enableQuickMode">Quick mode : Skip all confirmation pop-up</label>
                     <label class="switch">
                         <input type="checkbox" id="enableQuickMode">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div class="settings-switch" style="margin-bottom: 10px;">
+                    <label for="enableButtonAnimations">Glowing Animations</label>
+                    <label class="switch">
+                        <input type="checkbox" id="enableButtonAnimations">
                         <span class="slider"></span>
                     </label>
                 </div>

--- a/script.js
+++ b/script.js
@@ -179,6 +179,7 @@ let cookieIntervalId;
 let crunchTimer = 0;
 
 let enableQuickMode = false;
+let enableButtonAnimations = true;
 
 // Global object to manage prevent event occuring at the same time
 let eventProgression = {
@@ -408,6 +409,9 @@ function loadGameState() {
     
     // Retrieve quick mode
     enableQuickMode = localStorage.getItem('enableQuickMode') === 'true';
+
+    // Retrieve animation preferences
+    manageButtonAnimations(localStorage.getItem('enableButtonAnimations') == null ? true : localStorage.getItem('enableButtonAnimations') === 'true');
 
     // read multibuyUpgradesButtonsUnlocked from localstorage
     multibuyUpgradesButtonsUnlocked = JSON.parse(localStorage.getItem('multibuyUpgradesButtonsUnlocked')) || false;
@@ -642,6 +646,7 @@ function saveGameState() {
     localStorage.setItem('autoTranscendThreshold', autoTranscendThreshold);
 
     localStorage.setItem('enableQuickMode', enableQuickMode);
+    localStorage.setItem('enableButtonAnimations', enableButtonAnimations);
 
     localStorage.setItem('deadpoolRevives', deadpoolRevives);
     
@@ -3976,6 +3981,11 @@ function isEventInProgress() {
     return eventProgression.inProgress;
 }
 
+function manageButtonAnimations(enabled) {
+    enableButtonAnimations = enabled;
+    document.querySelector(':root').style.setProperty("--glowing-animation-duration", enabled ? "2s" : "0s")
+}
+
 // Expose functions to the global scope for use in the HTML
 window.prestige = prestige;
 window.updateDisplay = updateDisplay;
@@ -4062,6 +4072,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('enableQuickMode').addEventListener('change', function() {
         enableQuickMode = this.checked;
+    });
+
+    document.getElementById('enableButtonAnimations').addEventListener('change', function() {
+        manageButtonAnimations(this.checked);
     });
 
     // Library Skills -- has to happen before loadGameState!

--- a/settings.js
+++ b/settings.js
@@ -18,6 +18,12 @@ function openSettings() {
         const enableQuickModeSwitch = document.getElementById('enableQuickMode');
         enableQuickModeSwitch.checked = enableQuickMode;
     }, 0); // Adjust timeout if necessary
+
+    // EnableButtonAnimations : Use a timeout to ensure the checkbox is fully rendered before setting its state
+    setTimeout(() => {
+        const enableButtonAnimationsSwitch = document.getElementById('enableButtonAnimations');
+        enableButtonAnimationsSwitch.checked = enableButtonAnimations;
+    }, 0); // Adjust timeout if necessary
 }
 
 // Function to close the settings overlay

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+:root {
+    --glowing-animation-duration: 2s;
+}
+
 html, body {
     overflow-x: hidden;
     overscroll-behavior-x: none; /* Disable horizontal overscroll */
@@ -340,7 +344,7 @@ button.affordable-double-godmode {
     border: 2px solid #4b6cb7; /* A mix between blue and purple for the border */
     box-shadow: 0 0 20px #1e90ff, 0 0 20px #8e44ad, 0 0 30px #4b6cb7; /* Blue and Purple shadow for glow effect */
     transition: background-color 0.3s ease, box-shadow 0.3s ease;
-    animation: waveGlow 2s infinite linear; /* Wave-like glow animation */
+    animation: waveGlow var(--glowing-animation-duration) infinite linear; /* Wave-like glow animation */
 }
 
 button.affordable-double-godmode:hover {
@@ -591,14 +595,14 @@ button.disabled {
 /* Half Purple, Half Blue Glow for Double God Mode Purchased Upgrades */
 .purchased-upgrade-double-godmode img {
     box-shadow: 
-        0 0 40px #8e44ad, /* Purple glow */
-        0 0 40px #1e90ff, /* Blue glow */
-        0 0 80px #b565c8, /* Light purple glow */
-        0 0 80px #00bfff; /* Light blue glow */
+        10px 0 20px #8e44ad, /* Purple glow */
+        -5px 0 20px #1e90ff, /* Blue glow */
+        0 0 20px #b565c8,    /* Light purple glow */
+        -5px 0 20px #00bfff; /* Light blue glow */
     border: 5px solid;
     border-image: linear-gradient(45deg, #8e44ad, #1e90ff);
     border-image-slice: 1; /* To apply the gradient to the border */
-    animation: waveGlow 2s infinite linear; /* Wave-like glow animation */
+    animation: waveGlow var(--glowing-animation-duration) infinite linear; /* Wave-like glow animation */
 }
 
 /* Container for the multibuy buttons */


### PR DESCRIPTION
New Toggle in settings, "ON" by default in order to give to the player a way to disable the Glowing effect around both the Double God Mode button to purchase an upgrade and around the proper upgrade once bought.

100x less CPU usage during my comparison test between live and local version of the game.

![image](https://github.com/user-attachments/assets/8724d1b1-37ec-472e-bb95-c92f45824c58)
![image](https://github.com/user-attachments/assets/81110efe-1c8c-41cf-ba3e-6abd2c478f57)
