### PR TITLE
mobile: reset width of modal content

### DIFF
--- a/script.js
+++ b/script.js
@@ -4085,6 +4085,11 @@ function displayNextModal() {
         };
     } else {
         modalImage.style.display = 'none';
+        // reset refs to images from previous modals
+        modalImage.src = '';
+        modalContent.style.width = '';
+        modalContent.style.maxWidth = '';
+        
     }
 
     modal.style.display = 'block';


### PR DESCRIPTION
fixes issue with text overflowing screen width seen when opening a modal after prev opening one with image

steps to reproduce

1. be on mobile
2. open "what is degens" upgrade & close
3. open "you made it" upgrade

<img width="453" alt="image" src="https://github.com/user-attachments/assets/ecbf545b-12e3-4236-83e8-2a55c0629531">

preview build: https://fix-modal-mobile.degens-idle.pages.dev/