### PR TITLE
love hall button shown if any of its skills are unlocked

### DIFF
--- a/script.js
+++ b/script.js
@@ -527,13 +527,6 @@ function loadGameState() {
 
     twinRealmsSequence = localStorage.getItem('twinRealmsSequence') || '';
 
-    loveHallUnlocked = JSON.parse(localStorage.getItem('loveHallUnlocked')) || false;
-    // fix for some users experiencing error
-    let loveHallButton = document.getElementById('loveHallButton');
-    if (loveHallButton) {
-        loveHallButton.style.display = loveHallUnlocked ? 'flex' : 'none';
-    }
-
     // Retrieve and parse all upgrades with the isGodMode property from local storage
     const savedUpgrades = JSON.parse(localStorage.getItem('upgrades')) || [];
 
@@ -617,6 +610,21 @@ function loadGameState() {
                 }
             }
         });
+    }
+
+    loveHallUnlocked = JSON.parse(localStorage.getItem('loveHallUnlocked')) || false;
+    // fix for some users experiencing error
+    let loveHallButton = document.getElementById('loveHallButton');
+    if (loveHallButton) {
+        if (loveHallUnlocked) {
+            loveHallButton.style.display = 'flex';
+        } else {
+            loveHallButton.style.display = 'none';
+        }
+    }
+    
+    if (!loveHallUnlocked && savedLoveHallSkills.some(skill => skill.unlocked)) {
+        unlockHallofLove();
     }
 
     // Load unlocked skills


### PR DESCRIPTION
this solves the issue for users with save files that are missing `loveHallUnlocked: true` - it checks if they have any saved & unlocked LH skills, even after respec

preview build: https://love-hall-button-lost.degens-idle.pages.dev/